### PR TITLE
Serialization fixes

### DIFF
--- a/src/crypto_tools/k256_serde.rs
+++ b/src/crypto_tools/k256_serde.rs
@@ -120,7 +120,6 @@ impl std::ops::Mul<Scalar> for ProjectivePoint {
     }
 }
 
-
 impl AsRef<k256::ProjectivePoint> for ProjectivePoint {
     fn as_ref(&self) -> &k256::ProjectivePoint {
         &self.0
@@ -206,7 +205,7 @@ mod tests {
     #[test]
     fn basic_round_trip() {
         let s = Scalar::random(rand::thread_rng());
-        basic_round_trip_impl::<_, Scalar>(s, Some(32));
+        basic_round_trip_impl::<_, Scalar>(s, Some(33));
 
         let p = k256::ProjectivePoint::GENERATOR * s;
         basic_round_trip_impl::<_, ProjectivePoint>(p, None);
@@ -262,10 +261,12 @@ mod tests {
         too_many_bytes.push(42);
         bincode.deserialize::<S>(&too_many_bytes).unwrap_err();
 
-        let mut modulus: [u8; 32] = [
-            0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-            0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e, 0x8c,
-            0xd0, 0x36, 0x41, 0x41,
+        // As used by `serdect` serializer:
+        // array length (0x20) + 32 bytes of the serialized scalar.
+        let mut modulus: [u8; 33] = [
+            0x20, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xfe, 0xba, 0xae, 0xdc, 0xe6, 0xaf, 0x48, 0xa0, 0x3b, 0xbf, 0xd2, 0x5e,
+            0x8c, 0xd0, 0x36, 0x41, 0x41,
         ]; // secp256k1 modulus
 
         // test edge case: integer too large
@@ -273,7 +274,7 @@ mod tests {
 
         // test edge case: integer not too large
         // tk note: failing. I lack the knowledge about bincode to solve this quickly.
-        modulus[31] -= 1;
+        modulus[32] -= 1;
         bincode.deserialize::<S>(&modulus).unwrap();
     }
 }

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -78,7 +78,7 @@ pub fn sign(
         })?
         .0;
 
-    Ok(signature.to_vec())
+    Ok(signature.to_der().as_bytes().to_vec())
 }
 
 pub fn verify(

--- a/src/multisig/sign/r2.rs
+++ b/src/multisig/sign/r2.rs
@@ -87,7 +87,7 @@ impl Executer for R2 {
                 .share_to_party_subshare_ids(peer_keygen_id)?;
 
             valid_signatures.push(SignatureShare {
-                signature_bytes: signature.to_vec(),
+                signature_bytes: signature.to_der().as_bytes().to_vec(),
                 party_id,
                 subshare_id,
             });


### PR DESCRIPTION
This PR fixes the problems that caused test suite failures.
- The newtype for `k256::Scalar` that was recently removed contained a custom `serde` serialization, where just the 32 bytes of the scalar were serialized. Without it, the default behavior is defined by the [`serdect`](https://docs.rs/serdect/latest/serdect/) backend used in `k256`, and it explicitly serializes the array length too, making the total size 33 bytes. Ostensibly it is done to ensure constant-timeness, although I am not sure I understand how does it help in the case of a fixed-size array.
- In a couple of places `Signature` was not converted to DER before serialization. 
 
While I fixed the occurrences of that, the underlying cause was the dissolution of the signature newtype which led to the spatial separation and repetition of serialization/deserialization logic. A proper fix would be to restore the newtype (this applies to the newtype for the curve point as well, and possibly for the scalar).