### PR TITLE
Use a typed `Signature` instead of serialized bytes in the API

### DIFF
--- a/src/gg20/sign/api.rs
+++ b/src/gg20/sign/api.rs
@@ -4,7 +4,7 @@ use crate::{
         GroupPublicInfo, KeygenPartyId, KeygenShareId, SecretKeyShare, ShareSecretInfo,
     },
     sdk::{
-        api::{BytesVec, PartyShareCounts, Protocol, TofnFatal, TofnResult},
+        api::{PartyShareCounts, Protocol, Signature, TofnFatal, TofnResult},
         implementer_api::{new_protocol, ProtocolBuilder},
     },
 };
@@ -24,8 +24,8 @@ pub use crate::crypto_tools::message_digest::MessageDigest;
 /// The largest sign message is r2::P2pHappy with size ~6828 bytes on the wire.
 pub const MAX_MSG_LEN: usize = 7500;
 
-pub type SignProtocol = Protocol<BytesVec, SignShareId, SignPartyId, MAX_MSG_LEN>;
-pub type SignProtocolBuilder = ProtocolBuilder<BytesVec, SignShareId>;
+pub type SignProtocol = Protocol<Signature, SignShareId, SignPartyId, MAX_MSG_LEN>;
+pub type SignProtocolBuilder = ProtocolBuilder<Signature, SignShareId>;
 
 // This includes all shares participating in the current signing protocol
 pub type KeygenShareIds = VecMap<SignShareId, TypedUsize<KeygenShareId>>;

--- a/src/gg20/sign/malicious.rs
+++ b/src/gg20/sign/malicious.rs
@@ -82,7 +82,7 @@ pub fn delta_inverse_r3(
 
     let faulter_delta_i_change = faulter_bcast.delta_i + delta_i_sum_except_faulter;
 
-    faulter_bcast.delta_i = delta_i_sum_except_faulter.negate().into();
+    faulter_bcast.delta_i = delta_i_sum_except_faulter.negate();
 
     all_bcasts_deserialized.insert(faulter_share_id.as_usize(), faulter_bcast);
 

--- a/src/gg20/sign/r2.rs
+++ b/src/gg20/sign/r2.rs
@@ -6,7 +6,7 @@ use crate::{
     },
     gg20::keygen::{KeygenShareId, SecretKeyShare},
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnResult},
         implementer_api::{serialize, Executer, ProtocolBuilder, ProtocolInfo, RoundBuilder},
     },
 };
@@ -58,7 +58,7 @@ pub struct P2pSad {
 }
 
 impl Executer for R2 {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r1::Bcast;
     type P2p = r1::P2p;

--- a/src/gg20/sign/r3/happy.rs
+++ b/src/gg20/sign/r3/happy.rs
@@ -13,7 +13,7 @@ use crate::{
         },
     },
     sdk::{
-        api::{BytesVec, TofnFatal, TofnResult},
+        api::{Signature, TofnFatal, TofnResult},
         implementer_api::{serialize, Executer, ProtocolBuilder, ProtocolInfo, RoundBuilder},
     },
 };
@@ -67,7 +67,7 @@ pub(in super::super) enum Accusation {
 }
 
 impl Executer for R3Happy {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = ();
     type P2p = r2::P2p;

--- a/src/gg20/sign/r3/sad.rs
+++ b/src/gg20/sign/r3/sad.rs
@@ -6,7 +6,7 @@ use crate::{
         sign::{r3::common::R3Path, KeygenShareIds},
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{log_fault_info, Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
@@ -27,7 +27,7 @@ pub(in super::super) struct R3Sad {
 }
 
 impl Executer for R3Sad {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = ();
     type P2p = r2::P2p;

--- a/src/gg20/sign/r4/happy.rs
+++ b/src/gg20/sign/r4/happy.rs
@@ -10,7 +10,7 @@ use crate::{
         },
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnResult},
         implementer_api::{serialize, Executer, ProtocolBuilder, ProtocolInfo, RoundBuilder},
     },
 };
@@ -53,7 +53,7 @@ pub struct BcastHappy {
 }
 
 impl Executer for R4Happy {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r3::BcastHappy;
     type P2p = r3::P2pSad;

--- a/src/gg20/sign/r4/sad.rs
+++ b/src/gg20/sign/r4/sad.rs
@@ -3,7 +3,7 @@ use crate::{
     crypto_tools::{paillier, vss},
     gg20::{keygen::SecretKeyShare, sign::KeygenShareIds},
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{log_fault_info, Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
@@ -21,7 +21,7 @@ pub(in super::super) struct R4Sad {
 }
 
 impl Executer for R4Sad {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r3::BcastHappy;
     type P2p = r3::P2pSad;

--- a/src/gg20/sign/r5/happy.rs
+++ b/src/gg20/sign/r5/happy.rs
@@ -12,7 +12,7 @@ use crate::{
         sign::{r5::common::R5Path, type5_common},
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{serialize, Executer, ProtocolBuilder, ProtocolInfo, RoundBuilder},
     },
 };
@@ -62,7 +62,7 @@ pub(in super::super) struct P2p {
 }
 
 impl Executer for R5 {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r4::Bcast;
     type P2p = type5_common::P2pSadType5;

--- a/src/gg20/sign/r5/type5.rs
+++ b/src/gg20/sign/r5/type5.rs
@@ -10,7 +10,7 @@ use crate::{
         },
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
@@ -31,7 +31,7 @@ pub(in super::super) struct R5Type5 {
 }
 
 impl Executer for R5Type5 {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r4::Bcast;
     type P2p = type5_common::P2pSadType5;

--- a/src/gg20/sign/r6.rs
+++ b/src/gg20/sign/r6.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     gg20::keygen::{KeygenShareId, SecretKeyShare},
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnResult},
         implementer_api::{serialize, Executer, ProtocolBuilder, ProtocolInfo, RoundBuilder},
     },
 };
@@ -72,7 +72,7 @@ pub struct P2pSad {
 }
 
 impl Executer for R6 {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r5::Bcast;
     type P2p = r5::P2p;

--- a/src/gg20/sign/r7/happy.rs
+++ b/src/gg20/sign/r7/happy.rs
@@ -16,7 +16,7 @@ use crate::{
         },
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{serialize, Executer, ProtocolBuilder, ProtocolInfo, RoundBuilder},
     },
 };
@@ -51,7 +51,7 @@ pub(in super::super) struct R7Happy {
 }
 
 impl Executer for R7Happy {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r6::Bcast;
     type P2p = r6::P2p;

--- a/src/gg20/sign/r7/sad.rs
+++ b/src/gg20/sign/r7/sad.rs
@@ -6,7 +6,7 @@ use crate::{
         sign::{r7::common::R7Path, KeygenShareIds, SignShareId},
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{log_fault_info, Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
@@ -29,7 +29,7 @@ pub(in super::super) struct R7Sad {
 }
 
 impl Executer for R7Sad {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r6::Bcast;
     type P2p = r6::P2p;

--- a/src/gg20/sign/r7/type5.rs
+++ b/src/gg20/sign/r7/type5.rs
@@ -13,7 +13,7 @@ use crate::{
         },
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
@@ -36,7 +36,7 @@ pub(in super::super) struct R7Type5 {
 }
 
 impl Executer for R7Type5 {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r6::Bcast;
     type P2p = r6::P2p;

--- a/src/gg20/sign/r8/happy.rs
+++ b/src/gg20/sign/r8/happy.rs
@@ -2,12 +2,12 @@ use crate::{
     collections::{FillVecMap, P2ps, VecMap},
     gg20::{keygen::SecretKeyShare, sign::r8::common::R8Path},
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
 use ecdsa::hazmat::VerifyPrimitive;
-use k256::{ecdsa::Signature, ProjectivePoint, Scalar};
+use k256::{ProjectivePoint, Scalar};
 use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
 
@@ -33,7 +33,7 @@ pub(in super::super) struct Bcast {
 }
 
 impl Executer for R8Happy {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r7::Bcast;
     type P2p = r7::P2p;
@@ -94,10 +94,7 @@ impl Executer for R8Happy {
         let pub_key = &self.secret_key_share.group().y().as_ref().to_affine();
 
         if pub_key.verify_prehashed(self.msg_to_sign, &sig).is_ok() {
-            // convert signature into ASN1/DER (Bitcoin) format
-            let sig_bytes = sig.to_der().as_bytes().to_vec();
-
-            return Ok(ProtocolBuilder::Done(Ok(sig_bytes)));
+            return Ok(ProtocolBuilder::Done(Ok(sig)));
         }
 
         // verify proofs

--- a/src/gg20/sign/r8/type7.rs
+++ b/src/gg20/sign/r8/type7.rs
@@ -8,7 +8,7 @@ use crate::{
         sign::{r2, r8::common::R8Path, KeygenShareIds},
     },
     sdk::{
-        api::{BytesVec, Fault::ProtocolFault, TofnFatal, TofnResult},
+        api::{Fault::ProtocolFault, Signature, TofnFatal, TofnResult},
         implementer_api::{Executer, ProtocolBuilder, ProtocolInfo},
     },
 };
@@ -40,7 +40,7 @@ pub(in super::super) struct Bcast {
 }
 
 impl Executer for R8Type7 {
-    type FinalOutput = BytesVec;
+    type FinalOutput = Signature;
     type Index = SignShareId;
     type Bcast = r7::Bcast;
     type P2p = r7::P2p;

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,9 +121,7 @@ fn sign(cli: SignCli) -> anyhow::Result<()> {
     let sign_parties = {
         let mut sign_parties = SignParties::with_max_size(party_share_counts.party_count());
         for i in &cli.parties {
-            sign_parties
-                .add(TypedUsize::from_usize(*i as usize))
-                .unwrap();
+            sign_parties.add(TypedUsize::from_usize(*i)).unwrap();
         }
         sign_parties
     };
@@ -166,10 +164,9 @@ fn sign(cli: SignCli) -> anyhow::Result<()> {
         &k256::EncodedPoint::from_bytes(pubkey_bytes).unwrap(),
     )
     .unwrap();
-    let sig = k256::ecdsa::Signature::from_der(signatures.get(TypedUsize::from_usize(0)).unwrap())
-        .unwrap();
+    let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
     assert!(pubkey
-        .verify_prehashed(k256::Scalar::from(&msg_to_sign), &sig)
+        .verify_prehashed(k256::Scalar::from(&msg_to_sign), sig)
         .is_ok());
 
     info!(

--- a/src/multisig/sign/api.rs
+++ b/src/multisig/sign/api.rs
@@ -5,7 +5,7 @@ use crate::{
         GroupPublicInfo, KeygenPartyId, KeygenShareId, SecretKeyShare, ShareSecretInfo,
     },
     sdk::{
-        api::{BytesVec, PartyShareCounts, Protocol, TofnFatal, TofnResult},
+        api::{PartyShareCounts, Protocol, Signature, TofnFatal, TofnResult},
         implementer_api::{new_protocol, ProtocolBuilder},
     },
 };
@@ -18,7 +18,7 @@ pub use crate::crypto_tools::message_digest::MessageDigest;
 /// SignProtocol output for a single share in happy path
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SignatureShare {
-    pub signature_bytes: BytesVec, // ASN1/DER (Bitcoin) encoding
+    pub signature: Signature,
     pub party_id: TypedUsize<KeygenPartyId>,
     pub subshare_id: usize,
 }

--- a/src/multisig/sign/r2.rs
+++ b/src/multisig/sign/r2.rs
@@ -87,7 +87,7 @@ impl Executer for R2 {
                 .share_to_party_subshare_ids(peer_keygen_id)?;
 
             valid_signatures.push(SignatureShare {
-                signature_bytes: signature.to_der().as_bytes().to_vec(),
+                signature,
                 party_id,
                 subshare_id,
             });

--- a/src/multisig/sign/tests.rs
+++ b/src/multisig/sign/tests.rs
@@ -156,9 +156,8 @@ fn execute_sign(
             .unwrap()
             .as_ref()
             .to_affine();
-        let signature = k256::ecdsa::Signature::from_der(&sig_share.signature_bytes).unwrap();
         verifying_key
-            .verify_prehashed(hashed_msg, &signature)
+            .verify_prehashed(hashed_msg, &sig_share.signature)
             .unwrap();
     }
 }

--- a/src/sdk/api.rs
+++ b/src/sdk/api.rs
@@ -1,4 +1,6 @@
 //! API for tofn users
+pub use k256::ecdsa::Signature;
+
 pub type TofnResult<T> = Result<T, TofnFatal>;
 pub type BytesVec = Vec<u8>;
 

--- a/tests/integration/multi_thread/mod.rs
+++ b/tests/integration/multi_thread/mod.rs
@@ -128,8 +128,7 @@ fn basic_correctness() {
         &k256::EncodedPoint::from_bytes(pubkey_bytes).unwrap(),
     )
     .unwrap();
-    let sig = k256::ecdsa::Signature::from_der(signatures.get(TypedUsize::from_usize(0)).unwrap())
-        .unwrap();
+    let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
     assert!(pubkey
         .verify_prehashed(k256::Scalar::from(&msg_to_sign), &sig)
         .is_ok());

--- a/tests/integration/single_thread/malicious/sign.rs
+++ b/tests/integration/single_thread/malicious/sign.rs
@@ -12,7 +12,7 @@ use tofn::{
             new_sign, MessageDigest, SignParties, SignPartyId, SignShareId,
         },
     },
-    sdk::api::{BytesVec, Fault, PartyShareCounts, Protocol::*, ProtocolOutput},
+    sdk::api::{Fault, PartyShareCounts, Protocol::*, ProtocolOutput, Signature},
 };
 use tracing::info;
 
@@ -132,13 +132,13 @@ pub struct SingleFaultTestCaseList {
     pub threshold: usize,
     pub sign_parties: SignParties,
     // pub share_behaviours: VecMap<SignParticipantIndex, Behaviour>,
-    pub expected_honest_output: ProtocolOutput<BytesVec, SignPartyId>,
+    pub expected_honest_output: ProtocolOutput<Signature, SignPartyId>,
     pub cases: Vec<Behaviour>,
     pub malicious_sign_share_id: TypedUsize<SignShareId>,
 }
 
 impl SingleFaultTestCaseList {
-    pub fn assert_expected_output(&self, output: &ProtocolOutput<BytesVec, SignPartyId>) {
+    pub fn assert_expected_output(&self, output: &ProtocolOutput<Signature, SignPartyId>) {
         match output {
             Ok(_) => assert!(
                 self.expected_honest_output.is_ok(),

--- a/tests/integration/single_thread/malicious/sign_delta_inv.rs
+++ b/tests/integration/single_thread/malicious/sign_delta_inv.rs
@@ -9,7 +9,9 @@ use tofn::{
             new_sign, MessageDigest, SignParties, SignPartyId, SignProtocol, SignShareId,
         },
     },
-    sdk::api::{BytesVec, Fault, PartyShareCounts, Protocol, ProtocolOutput, TofnResult},
+    sdk::api::{
+        BytesVec, Fault, PartyShareCounts, Protocol, ProtocolOutput, Signature, TofnResult,
+    },
 };
 use tracing::{info, warn};
 
@@ -123,14 +125,14 @@ pub struct DeltaInvTestData {
     pub party_share_counts: PartyShareCounts<KeygenPartyId>,
     pub threshold: usize,
     pub sign_parties: SignParties,
-    pub expected_honest_output: ProtocolOutput<BytesVec, SignPartyId>,
+    pub expected_honest_output: ProtocolOutput<Signature, SignPartyId>,
     pub faulter_share_id: TypedUsize<SignShareId>,
     pub fault_type: DeltaInvFaultType,
     pub delta_i_change: Option<k256::Scalar>,
 }
 
 impl DeltaInvTestData {
-    pub fn assert_expected_output(&self, output: &ProtocolOutput<BytesVec, SignPartyId>) {
+    pub fn assert_expected_output(&self, output: &ProtocolOutput<Signature, SignPartyId>) {
         match output {
             Ok(_) => assert!(
                 self.expected_honest_output.is_ok(),

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -100,8 +100,7 @@ fn basic_correctness() {
         &k256::EncodedPoint::from_bytes(pubkey_bytes).unwrap(),
     )
     .unwrap();
-    let sig = k256::ecdsa::Signature::from_der(signatures.get(TypedUsize::from_usize(0)).unwrap())
-        .unwrap();
+    let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
     assert!(pubkey
         .verify_prehashed(k256::Scalar::from(&msg_to_sign), &sig)
         .is_ok());


### PR DESCRIPTION
The `Signature` type is exported from `tofn::sdk::api`.