### PR TITLE
Add a way to obtain a recoverable signature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ zeroize = { version = "1.4", features = ["zeroize_derive"] }
 hex = "0.4.3"
 
 # k256 baggage
-k256 = { version = "0.10.4", features = ["serde"] }
-ecdsa = "0.13.4"
+k256 = { version = "0.11.6", features = ["serde"] }
+ecdsa = "0.14.6"
 rand = "0.8"
 sha2 = { version = "0.10.2", features = [
   "std",

--- a/src/crypto_tools/k256_serde.rs
+++ b/src/crypto_tools/k256_serde.rs
@@ -105,10 +105,10 @@ impl ProjectivePoint {
 
     /// Decode from a SEC1-encoded curve point.
     pub fn from_bytes(bytes: &[u8]) -> Option<Self> {
-        Some(Self(
-            k256::ProjectivePoint::from_encoded_point(&k256::EncodedPoint::from_bytes(bytes).ok()?)
-                .unwrap(),
-        ))
+        let encoded_point = k256::EncodedPoint::from_bytes(bytes).ok()?;
+        let projective_point: Option<k256::ProjectivePoint> =
+            k256::ProjectivePoint::from_encoded_point(&encoded_point).into();
+        Some(Self(projective_point?))
     }
 }
 

--- a/src/crypto_tools/message_digest.rs
+++ b/src/crypto_tools/message_digest.rs
@@ -9,6 +9,12 @@ use std::{
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct MessageDigest([u8; 32]);
 
+impl AsRef<[u8]> for MessageDigest {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 impl TryFrom<&[u8]> for MessageDigest {
     type Error = TryFromSliceError;
     fn try_from(v: &[u8]) -> Result<Self, Self::Error> {

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -70,7 +70,7 @@ pub fn sign(
     let ephemeral_scalar = k256::Scalar::random(rng);
 
     let signature = signing_key
-        .try_sign_prehashed(ephemeral_scalar, message_digest)
+        .try_sign_prehashed(ephemeral_scalar, message_digest.into())
         .map_err(|_| {
             error!("failure to sign");
             TofnFatal
@@ -93,7 +93,7 @@ pub fn verify(
     Ok(verifying_key
         .as_ref()
         .to_affine()
-        .verify_prehashed(hashed_msg, signature)
+        .verify_prehashed(hashed_msg.into(), signature)
         .is_ok())
 }
 

--- a/src/gg20/keygen/secret_key_share.rs
+++ b/src/gg20/keygen/secret_key_share.rs
@@ -9,7 +9,7 @@ use crate::{
         implementer_api::{decode, encode},
     },
 };
-use k256::ProjectivePoint;
+use k256::{ecdsa::VerifyingKey, ProjectivePoint};
 use serde::{Deserialize, Serialize};
 use tracing::error;
 use zeroize::Zeroize;
@@ -74,11 +74,11 @@ impl GroupPublicInfo {
         self.threshold
     }
 
-    /// SEC1-encoded curve point
-    /// tofnd can send this data through grpc
-    /// TODO change return type to `[u8; 33]`?
-    pub fn encoded_pubkey(&self) -> BytesVec {
-        self.y.to_bytes().to_vec()
+    /// Verification key corresponding to this group of signers.
+    pub fn verifying_key(&self) -> VerifyingKey {
+        let pp: &k256::ProjectivePoint = self.y.as_ref();
+        let pk = k256::PublicKey::from_affine(pp.to_affine()).unwrap();
+        VerifyingKey::from(pk)
     }
 
     pub fn all_shares_bytes(&self) -> TofnResult<BytesVec> {

--- a/src/gg20/keygen/secret_key_share.rs
+++ b/src/gg20/keygen/secret_key_share.rs
@@ -77,16 +77,15 @@ impl GroupPublicInfo {
     /// Verification key corresponding to this group of signers.
     pub fn verifying_key(&self) -> VerifyingKey {
         let pp: &k256::ProjectivePoint = self.y.as_ref();
+        // TODO: this can only fail if the point is the infinity point,
+        // which cannot happen because of how it is constructed.
+        // This may be possible to enforce statically in the future.
         let pk = k256::PublicKey::from_affine(pp.to_affine()).unwrap();
         VerifyingKey::from(pk)
     }
 
     pub fn all_shares_bytes(&self) -> TofnResult<BytesVec> {
         encode(&self.all_shares)
-    }
-
-    pub fn y(&self) -> &k256_serde::ProjectivePoint {
-        &self.y
     }
 
     pub fn all_shares(&self) -> &VecMap<KeygenShareId, SharePublicInfo> {
@@ -102,6 +101,9 @@ impl GroupPublicInfo {
         Self {
             party_share_counts,
             threshold,
+            // TODO: this point is not an infinity point by construction
+            // (since it's the generator times a scalar), but there's no way at the moment
+            // to statically enforce it.
             y,
             all_shares,
         }

--- a/src/gg20/sign/r7/happy.rs
+++ b/src/gg20/sign/r7/happy.rs
@@ -147,7 +147,8 @@ impl Executer for R7Happy {
         // malicious actor falsely claim type 7 fault by comparing against a corrupted S_i_sum
         corrupt!(S_i_sum, self.corrupt_S_i_sum(info.my_id(), S_i_sum));
 
-        if &S_i_sum != self.secret_key_share.group().y().as_ref() {
+        let vk_point: ProjectivePoint = self.secret_key_share.group().verifying_key().into();
+        if S_i_sum != vk_point {
             warn!("peer {} says: 'type 7' fault detected", my_sign_id);
 
             // recover encryption randomness for mu; need to decrypt again to do so

--- a/src/gg20/sign/r8/happy.rs
+++ b/src/gg20/sign/r8/happy.rs
@@ -93,7 +93,10 @@ impl Executer for R8Happy {
 
         let pub_key = &self.secret_key_share.group().y().as_ref().to_affine();
 
-        if pub_key.verify_prehashed(self.msg_to_sign, &sig).is_ok() {
+        if pub_key
+            .verify_prehashed(self.msg_to_sign.into(), &sig)
+            .is_ok()
+        {
             return Ok(ProtocolBuilder::Done(Ok(sig)));
         }
 

--- a/src/gg20/sign/r8/happy.rs
+++ b/src/gg20/sign/r8/happy.rs
@@ -91,9 +91,10 @@ impl Executer for R8Happy {
             sig.normalize_s().unwrap_or(sig)
         };
 
-        let pub_key = &self.secret_key_share.group().y().as_ref().to_affine();
+        let vkey = &self.secret_key_share.group().verifying_key();
+        let point = k256::ProjectivePoint::from(vkey).to_affine();
 
-        if pub_key
+        if point
             .verify_prehashed(self.msg_to_sign.into(), &sig)
             .is_ok()
         {

--- a/src/gg20/sign/tests.rs
+++ b/src/gg20/sign/tests.rs
@@ -248,7 +248,7 @@ fn execute_sign(
 
     // TEST: signature verification
     let pub_key = y.to_affine();
-    assert!(pub_key.verify_prehashed(m, &sig).is_ok());
+    assert!(pub_key.verify_prehashed(m.into(), &sig).is_ok());
 }
 
 #[test]

--- a/src/gg20/sign/tests.rs
+++ b/src/gg20/sign/tests.rs
@@ -158,9 +158,9 @@ fn execute_sign(
     let y = ProjectivePoint::GENERATOR * x;
 
     for (keygen_id, key_share) in &key_shares {
+        let y_from_vk: ProjectivePoint = key_share.group().verifying_key().into();
         assert_eq!(
-            y,
-            *key_share.group().y().as_ref(),
+            y, y_from_vk,
             "Share {} has invalid group public key",
             keygen_id
         );

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ fn sign(cli: SignCli) -> anyhow::Result<()> {
     .unwrap();
     let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
     assert!(pubkey
-        .verify_prehashed(k256::Scalar::from(&msg_to_sign), sig)
+        .verify_prehashed(k256::Scalar::from(&msg_to_sign).into(), sig)
         .is_ok());
 
     info!(

--- a/src/multisig/sign/api.rs
+++ b/src/multisig/sign/api.rs
@@ -101,11 +101,11 @@ mod tests {
         let hashed_msg = k256::Scalar::random(rand::thread_rng());
         let ephemeral_scalar = k256::Scalar::random(rand::thread_rng());
         let signature = signing_key
-            .try_sign_prehashed(ephemeral_scalar, hashed_msg)
+            .try_sign_prehashed(ephemeral_scalar, hashed_msg.into())
             .unwrap();
         let verifying_key = (k256::ProjectivePoint::GENERATOR * signing_key).to_affine();
         verifying_key
-            .verify_prehashed(hashed_msg, &signature.0)
+            .verify_prehashed(hashed_msg.into(), &signature.0)
             .unwrap();
     }
 }

--- a/src/multisig/sign/r1.rs
+++ b/src/multisig/sign/r1.rs
@@ -35,7 +35,7 @@ pub(super) fn start(
     let ephemeral_scalar = k256::Scalar::random(rng);
 
     let signature = signing_key
-        .try_sign_prehashed(ephemeral_scalar, msg_to_sign)
+        .try_sign_prehashed(ephemeral_scalar, msg_to_sign.into())
         .map_err(|_| TofnFatal)?;
 
     let bcast_out = Some(serialize(&Bcast {

--- a/src/multisig/sign/r2.rs
+++ b/src/multisig/sign/r2.rs
@@ -68,7 +68,7 @@ impl Executer for R2 {
                 .to_affine();
 
             if verifying_key
-                .verify_prehashed(self.msg_to_sign, &signature)
+                .verify_prehashed(self.msg_to_sign.into(), &signature)
                 .is_err()
             {
                 warn!(

--- a/src/multisig/sign/tests.rs
+++ b/src/multisig/sign/tests.rs
@@ -157,7 +157,7 @@ fn execute_sign(
             .as_ref()
             .to_affine();
         verifying_key
-            .verify_prehashed(hashed_msg, &sig_share.signature)
+            .verify_prehashed(hashed_msg.into(), &sig_share.signature)
             .unwrap();
     }
 }

--- a/src/sdk/api.rs
+++ b/src/sdk/api.rs
@@ -1,5 +1,5 @@
 //! API for tofn users
-pub use k256::ecdsa::Signature;
+pub use k256::ecdsa::{recoverable::Signature as RecoverableSignature, Signature, VerifyingKey};
 
 pub type TofnResult<T> = Result<T, TofnFatal>;
 pub type BytesVec = Vec<u8>;
@@ -23,3 +23,13 @@ pub use super::wire_bytes::{deserialize, serialize};
 
 #[cfg(feature = "malicious")]
 pub use super::wire_bytes::MsgType;
+
+pub fn to_recoverable_signature(
+    verifying_key: &VerifyingKey,
+    message: &[u8],
+    signature: &Signature,
+) -> Option<RecoverableSignature> {
+    let message_array = k256::FieldBytes::from_exact_iter(message.iter().cloned())?;
+    RecoverableSignature::from_digest_bytes_trial_recovery(verifying_key, &message_array, signature)
+        .ok()
+}

--- a/tests/integration/multi_thread/mod.rs
+++ b/tests/integration/multi_thread/mod.rs
@@ -130,7 +130,7 @@ fn basic_correctness() {
     .unwrap();
     let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
     assert!(pubkey
-        .verify_prehashed(k256::Scalar::from(&msg_to_sign), &sig)
+        .verify_prehashed(k256::Scalar::from(&msg_to_sign).into(), &sig)
         .is_ok());
 }
 

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -1,7 +1,7 @@
 use std::convert::TryFrom;
 
 use crate::common;
-use ecdsa::{elliptic_curve::sec1::FromEncodedPoint, hazmat::VerifyPrimitive};
+use ecdsa::signature::hazmat::PrehashVerifier;
 use execute::*;
 use tofn::{
     collections::{TypedUsize, VecMap},
@@ -89,21 +89,15 @@ fn basic_correctness() {
     });
 
     // grab pubkey bytes from one of the shares
-    let pubkey_bytes = secret_key_shares
+    let vkey = secret_key_shares
         .get(TypedUsize::from_usize(0))
         .unwrap()
         .group()
-        .encoded_pubkey();
+        .verifying_key();
 
     // verify a signature
-    let pubkey = k256::AffinePoint::from_encoded_point(
-        &k256::EncodedPoint::from_bytes(pubkey_bytes).unwrap(),
-    )
-    .unwrap();
     let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
-    assert!(pubkey
-        .verify_prehashed(k256::Scalar::from(&msg_to_sign).into(), &sig)
-        .is_ok());
+    assert!(vkey.verify_prehash(msg_to_sign.as_ref(), sig).is_ok());
 }
 
 mod execute;

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -102,7 +102,7 @@ fn basic_correctness() {
     .unwrap();
     let sig = signatures.get(TypedUsize::from_usize(0)).unwrap();
     assert!(pubkey
-        .verify_prehashed(k256::Scalar::from(&msg_to_sign), &sig)
+        .verify_prehashed(k256::Scalar::from(&msg_to_sign).into(), &sig)
         .is_ok());
 }
 


### PR DESCRIPTION
- Bump k256 to 0.11 (has some important fixes and performance improvements)
- add `to_recoverable_signature()` method
- add a `verifying_key()` method to the group info to provide a high-level `VerifyingKey` object