### PR TITLE
No-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1.4", features = ["zeroize_derive"] }
 hex = "0.4.3"
 
 # k256 baggage
-k256 = { version = "0.10.4", features = ["serde"] }
+k256 = { version = "0.10.4", default-features = false, features = ["serde", "ecdsa"] }
 ecdsa = { version = "0.13.4", features = ["hazmat"] }
 rand = "0.8"
 sha2 = { version = "0.10.2", features = [

--- a/benches/safe_primes.rs
+++ b/benches/safe_primes.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use core::borrow::Borrow;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use libpaillier::{unknown_order::BigNumber, DecryptionKey, EncryptionKey};

--- a/src/collections/fillholevecmap.rs
+++ b/src/collections/fillholevecmap.rs
@@ -50,7 +50,7 @@ impl<K, V> FillHoleVecMap<K, V> {
     pub fn is_empty(&self) -> bool {
         self.some_count == 0
     }
-    pub fn iter(&self) -> HoleVecMapIter<K, std::slice::Iter<Option<V>>> {
+    pub fn iter(&self) -> HoleVecMapIter<K, core::slice::Iter<Option<V>>> {
         self.hole_vec.iter()
     }
     pub fn map_to_holevec<W, F>(self, mut f: F) -> TofnResult<HoleVecMap<K, W>>
@@ -65,7 +65,7 @@ impl<K, V> FillHoleVecMap<K, V> {
             .map2_result(|(_, x)| Ok(f(x.ok_or(TofnFatal)?)))
     }
     pub fn to_holevec(self) -> TofnResult<HoleVecMap<K, V>> {
-        self.map_to_holevec(std::convert::identity)
+        self.map_to_holevec(core::convert::identity)
     }
 
     pub fn map<W, F>(self, mut f: F) -> FillHoleVecMap<K, W>
@@ -104,8 +104,8 @@ impl<K, V> FillHoleVecMap<K, V> {
 }
 
 impl<K, V> IntoIterator for FillHoleVecMap<K, V> {
-    type Item = <HoleVecMapIter<K, std::vec::IntoIter<Option<V>>> as Iterator>::Item;
-    type IntoIter = HoleVecMapIter<K, std::vec::IntoIter<Option<V>>>;
+    type Item = <HoleVecMapIter<K, alloc::vec::IntoIter<Option<V>>> as Iterator>::Item;
+    type IntoIter = HoleVecMapIter<K, alloc::vec::IntoIter<Option<V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.hole_vec.into_iter()
@@ -117,9 +117,9 @@ impl<K, V> IntoIterator for FillHoleVecMap<K, V> {
 impl<'a, K, V> IntoIterator for &'a FillHoleVecMap<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::slice::Iter<'a, Option<V>> as Iterator>::Item,
+        <core::slice::Iter<'a, Option<V>> as Iterator>::Item,
     );
-    type IntoIter = HoleVecMapIter<K, std::slice::Iter<'a, Option<V>>>;
+    type IntoIter = HoleVecMapIter<K, core::slice::Iter<'a, Option<V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/collections/fillp2ps.rs
+++ b/src/collections/fillp2ps.rs
@@ -72,10 +72,10 @@ impl<K, V> FillP2ps<K, V> {
         ))
     }
     pub fn to_fullp2ps(self) -> TofnResult<FullP2ps<K, V>> {
-        self.map_to_fullp2ps(std::convert::identity)
+        self.map_to_fullp2ps(core::convert::identity)
     }
     pub fn to_p2ps(self) -> TofnResult<P2ps<K, V>> {
-        self.map_to_p2ps(std::convert::identity)
+        self.map_to_p2ps(core::convert::identity)
     }
     pub fn map<W, F>(self, mut f: F) -> FillP2ps<K, W>
     where
@@ -93,14 +93,14 @@ impl<K, V> FillP2ps<K, V> {
         ))
     }
 
-    pub fn iter(&self) -> VecMapIter<K, std::slice::Iter<FillHoleVecMap<K, V>>> {
+    pub fn iter(&self) -> VecMapIter<K, core::slice::Iter<FillHoleVecMap<K, V>>> {
         self.0.iter()
     }
 
     pub fn iter_from(
         &self,
         from: TypedUsize<K>,
-    ) -> TofnResult<HoleVecMapIter<K, std::slice::Iter<Option<V>>>> {
+    ) -> TofnResult<HoleVecMapIter<K, core::slice::Iter<Option<V>>>> {
         Ok(self.0.get(from)?.iter())
     }
 }
@@ -108,9 +108,9 @@ impl<K, V> FillP2ps<K, V> {
 impl<K, V> IntoIterator for FillP2ps<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::vec::IntoIter<FillHoleVecMap<K, V>> as Iterator>::Item,
+        <alloc::vec::IntoIter<FillHoleVecMap<K, V>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::vec::IntoIter<FillHoleVecMap<K, V>>>;
+    type IntoIter = VecMapIter<K, alloc::vec::IntoIter<FillHoleVecMap<K, V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -122,9 +122,9 @@ impl<K, V> IntoIterator for FillP2ps<K, V> {
 impl<'a, K, V> IntoIterator for &'a FillP2ps<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::slice::Iter<'a, FillHoleVecMap<K, V>> as Iterator>::Item,
+        <core::slice::Iter<'a, FillHoleVecMap<K, V>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::slice::Iter<'a, FillHoleVecMap<K, V>>>;
+    type IntoIter = VecMapIter<K, core::slice::Iter<'a, FillHoleVecMap<K, V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/collections/fillvecmap.rs
+++ b/src/collections/fillvecmap.rs
@@ -1,5 +1,7 @@
 //! A fillable VecMap
-use std::iter::FromIterator;
+
+use alloc::vec::Vec;
+use core::iter::FromIterator;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tracing::error;
@@ -57,7 +59,7 @@ impl<K, V> FillVecMap<K, V> {
     pub fn some_count(&self) -> usize {
         self.some_count
     }
-    pub fn iter(&self) -> VecMapIter<K, std::slice::Iter<Option<V>>> {
+    pub fn iter(&self) -> VecMapIter<K, core::slice::Iter<Option<V>>> {
         self.vec.iter()
     }
 
@@ -84,7 +86,7 @@ impl<K, V> FillVecMap<K, V> {
     }
 
     pub fn to_vecmap(self) -> TofnResult<VecMap<K, V>> {
-        self.map_to_vecmap(std::convert::identity)
+        self.map_to_vecmap(core::convert::identity)
     }
 
     pub fn map<W, F>(self, mut f: F) -> FillVecMap<K, W>
@@ -148,8 +150,8 @@ impl<K, V> FillVecMap<K, V> {
 }
 
 impl<K, V> IntoIterator for FillVecMap<K, V> {
-    type Item = <VecMapIter<K, std::vec::IntoIter<Option<V>>> as Iterator>::Item;
-    type IntoIter = VecMapIter<K, std::vec::IntoIter<Option<V>>>;
+    type Item = <VecMapIter<K, alloc::vec::IntoIter<Option<V>>> as Iterator>::Item;
+    type IntoIter = VecMapIter<K, alloc::vec::IntoIter<Option<V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.vec.into_iter()
@@ -161,9 +163,9 @@ impl<K, V> IntoIterator for FillVecMap<K, V> {
 impl<'a, K, V> IntoIterator for &'a FillVecMap<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::slice::Iter<'a, Option<V>> as Iterator>::Item,
+        <core::slice::Iter<'a, Option<V>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::slice::Iter<'a, Option<V>>>;
+    type IntoIter = VecMapIter<K, core::slice::Iter<'a, Option<V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/collections/fullp2ps.rs
+++ b/src/collections/fullp2ps.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use tracing::error;
 
 use crate::{
@@ -49,10 +50,10 @@ impl<K, V> FullP2ps<K, V> {
         }))
     }
 
-    // pub fn iter(&self) -> P2psIter<K, std::slice::Iter<HoleVecMap<K, V>>, std::slice::Iter<V>> {
+    // pub fn iter(&self) -> P2psIter<K, core::slice::Iter<HoleVecMap<K, V>>, core::slice::Iter<V>> {
     //     P2psIter::new(self.0.iter())
     // }
-    pub fn iter(&self) -> VecMapIter<K, std::slice::Iter<HoleVecMap<K, V>>> {
+    pub fn iter(&self) -> VecMapIter<K, core::slice::Iter<HoleVecMap<K, V>>> {
         self.0.iter()
     }
 
@@ -104,9 +105,9 @@ impl<K, V> FullP2ps<K, V> {
 impl<K, V> IntoIterator for FullP2ps<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::vec::IntoIter<HoleVecMap<K, V>> as Iterator>::Item,
+        <alloc::vec::IntoIter<HoleVecMap<K, V>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::vec::IntoIter<HoleVecMap<K, V>>>;
+    type IntoIter = VecMapIter<K, alloc::vec::IntoIter<HoleVecMap<K, V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -118,9 +119,9 @@ impl<K, V> IntoIterator for FullP2ps<K, V> {
 impl<'a, K, V> IntoIterator for &'a FullP2ps<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::slice::Iter<'a, HoleVecMap<K, V>> as Iterator>::Item,
+        <core::slice::Iter<'a, HoleVecMap<K, V>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::slice::Iter<'a, HoleVecMap<K, V>>>;
+    type IntoIter = VecMapIter<K, core::slice::Iter<'a, HoleVecMap<K, V>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/collections/holevecmap.rs
+++ b/src/collections/holevecmap.rs
@@ -50,7 +50,7 @@ impl<K, V> HoleVecMap<K, V> {
         self.vec
     }
 
-    pub fn iter(&self) -> HoleVecMapIter<K, std::slice::Iter<V>> {
+    pub fn iter(&self) -> HoleVecMapIter<K, core::slice::Iter<V>> {
         HoleVecMapIter::new(self.vec.iter(), self.hole)
     }
 
@@ -117,8 +117,8 @@ impl<K, V> HoleVecMap<K, V> {
 }
 
 impl<K, V> IntoIterator for HoleVecMap<K, V> {
-    type Item = (TypedUsize<K>, <std::vec::IntoIter<V> as Iterator>::Item);
-    type IntoIter = HoleVecMapIter<K, std::vec::IntoIter<V>>;
+    type Item = (TypedUsize<K>, <alloc::vec::IntoIter<V> as Iterator>::Item);
+    type IntoIter = HoleVecMapIter<K, alloc::vec::IntoIter<V>>;
 
     fn into_iter(self) -> Self::IntoIter {
         HoleVecMapIter::new(self.vec.into_iter(), self.hole)
@@ -128,8 +128,8 @@ impl<K, V> IntoIterator for HoleVecMap<K, V> {
 /// impl IntoIterator for &HoleVecMap as suggested here: https://doc.rust-lang.org/std/iter/index.html#iterating-by-reference
 /// follow the template of Vec: https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#2451-2458
 impl<'a, K, V> IntoIterator for &'a HoleVecMap<K, V> {
-    type Item = (TypedUsize<K>, <std::slice::Iter<'a, V> as Iterator>::Item);
-    type IntoIter = HoleVecMapIter<K, std::slice::Iter<'a, V>>;
+    type Item = (TypedUsize<K>, <core::slice::Iter<'a, V> as Iterator>::Item);
+    type IntoIter = HoleVecMapIter<K, core::slice::Iter<'a, V>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/collections/holevecmap_iter.rs
+++ b/src/collections/holevecmap_iter.rs
@@ -1,6 +1,6 @@
 use super::{vecmap_iter::VecMapIter, TypedUsize};
 
-/// Follows the implementation of std::iter::Enumerate https://doc.rust-lang.org/std/iter/struct.Enumerate.html
+/// Follows the implementation of core::iter::Enumerate https://doc.rust-lang.org/std/iter/struct.Enumerate.html
 pub struct HoleVecMapIter<K, I> {
     iter: VecMapIter<K, I>,
     hole: TypedUsize<K>,

--- a/src/collections/p2ps.rs
+++ b/src/collections/p2ps.rs
@@ -1,3 +1,4 @@
+use alloc::vec;
 use tracing::error;
 
 use crate::{
@@ -26,7 +27,7 @@ impl<K, V> P2ps<K, V> {
         self.0.get(from)
     }
 
-    pub fn iter(&self) -> VecMapIter<K, std::slice::Iter<Option<HoleVecMap<K, V>>>> {
+    pub fn iter(&self) -> VecMapIter<K, core::slice::Iter<Option<HoleVecMap<K, V>>>> {
         self.0.iter()
     }
 
@@ -56,7 +57,7 @@ impl<K, V> P2ps<K, V> {
         )?))
     }
     pub fn to_fullp2ps(self) -> TofnResult<FullP2ps<K, V>> {
-        self.map_to_fullp2ps(std::convert::identity)
+        self.map_to_fullp2ps(core::convert::identity)
     }
 
     // private constructor does no checks, does not return TofnResult, cannot panic
@@ -69,9 +70,9 @@ impl<K, V> P2ps<K, V> {
 impl<K, V> IntoIterator for P2ps<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::vec::IntoIter<Option<HoleVecMap<K, V>>> as Iterator>::Item,
+        <alloc::vec::IntoIter<Option<HoleVecMap<K, V>>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::vec::IntoIter<Option<HoleVecMap<K, V>>>>;
+    type IntoIter = VecMapIter<K, alloc::vec::IntoIter<Option<HoleVecMap<K, V>>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
@@ -84,9 +85,9 @@ impl<K, V> IntoIterator for P2ps<K, V> {
 impl<'a, K, V> IntoIterator for &'a P2ps<K, V> {
     type Item = (
         TypedUsize<K>,
-        <std::slice::Iter<'a, Option<HoleVecMap<K, V>>> as Iterator>::Item,
+        <core::slice::Iter<'a, Option<HoleVecMap<K, V>>> as Iterator>::Item,
     );
-    type IntoIter = VecMapIter<K, std::slice::Iter<'a, Option<HoleVecMap<K, V>>>>;
+    type IntoIter = VecMapIter<K, core::slice::Iter<'a, Option<HoleVecMap<K, V>>>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()
@@ -96,6 +97,8 @@ impl<'a, K, V> IntoIterator for &'a P2ps<K, V> {
 #[cfg(test)]
 mod tests {
     use crate::collections::{FillP2ps, TypedUsize};
+    use alloc::vec;
+    use alloc::vec::Vec;
 
     struct TestIndex;
 

--- a/src/collections/p2ps_iter.rs
+++ b/src/collections/p2ps_iter.rs
@@ -1,6 +1,6 @@
 use super::{holevecmap_iter::HoleVecMapIter, vecmap_iter::VecMapIter, TypedUsize};
 
-// follow the example of std::iter::Flatten: https://doc.rust-lang.org/src/core/iter/adapters/flatten.rs.html#251-278
+// follow the example of core::iter::Flatten: https://doc.rust-lang.org/src/core/iter/adapters/flatten.rs.html#251-278
 pub struct P2psIter<K, I0, I1> {
     iter0: VecMapIter<K, I0>,
     iter1: Option<HoleVecMapIter<K, I1>>,

--- a/src/collections/typed_usize.rs
+++ b/src/collections/typed_usize.rs
@@ -1,5 +1,5 @@
+use core::marker::PhantomData;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::marker::PhantomData;
 use zeroize::Zeroize;
 
 pub struct TypedUsize<K>(usize, PhantomData<K>);
@@ -38,14 +38,14 @@ impl<K> Clone for TypedUsize<K> {
     }
 }
 
-impl<K> std::fmt::Debug for TypedUsize<K> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<K> core::fmt::Debug for TypedUsize<K> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<K> std::fmt::Display for TypedUsize<K> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<K> core::fmt::Display for TypedUsize<K> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/src/collections/vecmap.rs
+++ b/src/collections/vecmap.rs
@@ -1,5 +1,7 @@
+use alloc::vec::Vec;
+
+use core::iter::FromIterator;
 use serde::{Deserialize, Serialize};
-use std::iter::FromIterator;
 use tracing::error;
 use zeroize::Zeroize;
 
@@ -8,7 +10,7 @@ use crate::sdk::api::{TofnFatal, TofnResult};
 use super::{vecmap_iter::VecMapIter, HoleVecMap, TypedUsize};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct VecMap<K, V>(Vec<V>, std::marker::PhantomData<TypedUsize<K>>);
+pub struct VecMap<K, V>(Vec<V>, core::marker::PhantomData<TypedUsize<K>>);
 
 impl<K, V> Zeroize for VecMap<K, V>
 where
@@ -21,7 +23,7 @@ where
 
 impl<K, V> VecMap<K, V> {
     pub fn from_vec(vec: Vec<V>) -> Self {
-        Self(vec, std::marker::PhantomData)
+        Self(vec, core::marker::PhantomData)
     }
     pub fn into_vec(self) -> Vec<V> {
         self.0
@@ -63,10 +65,10 @@ impl<K, V> VecMap<K, V> {
         Ok(HoleVecMap::from_vecmap(self, hole))
     }
 
-    pub fn iter(&self) -> VecMapIter<K, std::slice::Iter<V>> {
+    pub fn iter(&self) -> VecMapIter<K, core::slice::Iter<V>> {
         VecMapIter::new(self.0.iter())
     }
-    pub fn iter_mut(&mut self) -> VecMapIter<K, std::slice::IterMut<V>> {
+    pub fn iter_mut(&mut self) -> VecMapIter<K, core::slice::IterMut<V>> {
         VecMapIter::new(self.0.iter_mut())
     }
     pub fn map<W, F>(self, f: F) -> VecMap<K, W>
@@ -107,8 +109,8 @@ impl<K, V> VecMap<K, V> {
 }
 
 impl<K, V> IntoIterator for VecMap<K, V> {
-    type Item = (TypedUsize<K>, <std::vec::IntoIter<V> as Iterator>::Item);
-    type IntoIter = VecMapIter<K, std::vec::IntoIter<V>>;
+    type Item = (TypedUsize<K>, <alloc::vec::IntoIter<V> as Iterator>::Item);
+    type IntoIter = VecMapIter<K, alloc::vec::IntoIter<V>>;
 
     fn into_iter(self) -> Self::IntoIter {
         VecMapIter::new(self.0.into_iter())
@@ -118,8 +120,8 @@ impl<K, V> IntoIterator for VecMap<K, V> {
 /// impl IntoIterator for &VecMap as suggested here: https://doc.rust-lang.org/std/iter/index.html#iterating-by-reference
 /// follow the template of Vec: https://doc.rust-lang.org/src/alloc/vec/mod.rs.html#2451-2458
 impl<'a, K, V> IntoIterator for &'a VecMap<K, V> {
-    type Item = (TypedUsize<K>, <std::slice::Iter<'a, V> as Iterator>::Item);
-    type IntoIter = VecMapIter<K, std::slice::Iter<'a, V>>;
+    type Item = (TypedUsize<K>, <core::slice::Iter<'a, V> as Iterator>::Item);
+    type IntoIter = VecMapIter<K, core::slice::Iter<'a, V>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.iter()

--- a/src/collections/vecmap_iter.rs
+++ b/src/collections/vecmap_iter.rs
@@ -1,6 +1,6 @@
 use super::TypedUsize;
 
-/// Follows the implementation of std::iter::Enumerate https://doc.rust-lang.org/std/iter/struct.Enumerate.html
+/// Follows the implementation of core::iter::Enumerate https://doc.rust-lang.org/std/iter/struct.Enumerate.html
 pub struct VecMapIter<K, I> {
     iter: I,
     count: TypedUsize<K>,

--- a/src/collections/vecmap_zip.rs
+++ b/src/collections/vecmap_zip.rs
@@ -18,7 +18,7 @@ pub fn zip3<K, I0, I1, I2>(
 pub struct Zip2<K, I0, I1> {
     iter0: VecMapIter<K, I0>,
     iter1: VecMapIter<K, I1>,
-    phantom: std::marker::PhantomData<K>,
+    phantom: core::marker::PhantomData<K>,
 }
 
 impl<K, I0, I1> Zip2<K, I0, I1> {
@@ -26,7 +26,7 @@ impl<K, I0, I1> Zip2<K, I0, I1> {
         Self {
             iter0,
             iter1,
-            phantom: std::marker::PhantomData,
+            phantom: core::marker::PhantomData,
         }
     }
 }
@@ -53,7 +53,7 @@ pub struct Zip3<K, I0, I1, I2> {
     iter0: VecMapIter<K, I0>,
     iter1: VecMapIter<K, I1>,
     iter2: VecMapIter<K, I2>,
-    phantom: std::marker::PhantomData<K>,
+    phantom: core::marker::PhantomData<K>,
 }
 
 impl<K, I0, I1, I2> Zip3<K, I0, I1, I2> {
@@ -66,7 +66,7 @@ impl<K, I0, I1, I2> Zip3<K, I0, I1, I2> {
             iter0,
             iter1,
             iter2,
-            phantom: std::marker::PhantomData,
+            phantom: core::marker::PhantomData,
         }
     }
 }

--- a/src/crypto_tools/k256_serde.rs
+++ b/src/crypto_tools/k256_serde.rs
@@ -77,7 +77,7 @@ struct EncodedPointVisitor;
 impl<'de> Visitor<'de> for EncodedPointVisitor {
     type Value = EncodedPoint;
 
-    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
         formatter.write_str("SEC1-encoded secp256k1 (K-256) curve point")
     }
 
@@ -112,7 +112,7 @@ impl ProjectivePoint {
     }
 }
 
-impl std::ops::Mul<Scalar> for ProjectivePoint {
+impl core::ops::Mul<Scalar> for ProjectivePoint {
     type Output = Self;
 
     fn mul(self, rhs: Scalar) -> Self::Output {
@@ -197,10 +197,10 @@ fn to_array33(g: GenericArray<u8, U33>) -> [u8; 33] {
 mod tests {
     use super::*;
     use bincode::Options;
+    use core::fmt::Debug;
     use ecdsa::hazmat::{SignPrimitive, VerifyPrimitive};
     use k256::{ecdsa::Signature, elliptic_curve::Field, Scalar};
     use serde::de::DeserializeOwned;
-    use std::fmt::Debug;
 
     #[test]
     fn basic_round_trip() {

--- a/src/crypto_tools/message_digest.rs
+++ b/src/crypto_tools/message_digest.rs
@@ -1,9 +1,9 @@
-use ecdsa::elliptic_curve::ops::Reduce;
-use serde::{Deserialize, Serialize};
-use std::{
+use core::{
     array::TryFromSliceError,
     convert::{TryFrom, TryInto},
 };
+use ecdsa::elliptic_curve::ops::Reduce;
+use serde::{Deserialize, Serialize};
 
 /// Sign only 32-byte hash digests
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/crypto_tools/mta.rs
+++ b/src/crypto_tools/mta.rs
@@ -128,7 +128,7 @@ pub fn mta_response_with_proof_wc(
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Borrow;
+    use core::borrow::Borrow;
 
     use super::{mta_response_with_proof_wc, verify_mta_response};
     use crate::{

--- a/src/crypto_tools/paillier/mod.rs
+++ b/src/crypto_tools/paillier/mod.rs
@@ -3,7 +3,9 @@
 //! * provide an ergonomic API
 //! * facilitate easy swap-out of Paillier back-end
 
-use std::borrow::Borrow;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
 
 use ecdsa::elliptic_curve::ops::Reduce;
 use libpaillier::unknown_order::BigNumber;

--- a/src/crypto_tools/paillier/zk/mod.rs
+++ b/src/crypto_tools/paillier/zk/mod.rs
@@ -1,4 +1,7 @@
 //! Minimize direct use of paillier, zk_paillier crates
+
+use alloc::vec::Vec;
+
 use crate::{crypto_tools::constants, sdk::api::TofnResult};
 
 use super::{keygen, keygen_unsafe, DecryptionKey, EncryptionKey, Plaintext, Randomness};

--- a/src/crypto_tools/paillier/zk/mta.rs
+++ b/src/crypto_tools/paillier/zk/mta.rs
@@ -1,3 +1,5 @@
+use alloc::borrow::ToOwned;
+
 use crate::{
     collections::TypedUsize,
     crypto_tools::{
@@ -447,6 +449,9 @@ pub mod malicious {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use alloc::format;
+    use alloc::string::{String, ToString};
+
     use super::{
         malicious::{corrupt_proof, corrupt_proof_wc},
         BigNumber, Proof, Statement, StatementWc, Witness, ZkSetup,

--- a/src/crypto_tools/paillier/zk/paillier_key.rs
+++ b/src/crypto_tools/paillier/zk/paillier_key.rs
@@ -5,6 +5,8 @@
 /// (which also implies that N is square-free).
 /// Parameters M = 11, alpha = 6370 have been selected from
 /// Section 6.2.3 of https://eprint.iacr.org/2018/987.pdf
+use alloc::vec;
+
 use libpaillier::unknown_order::BigNumber;
 use serde::{Deserialize, Serialize};
 use sha2::digest::*;

--- a/src/crypto_tools/paillier/zk/paillier_key.rs
+++ b/src/crypto_tools/paillier/zk/paillier_key.rs
@@ -232,9 +232,12 @@ mod tests {
     #[test]
     fn test_primorial() {
         let alpha = 6370;
-        let mut primorial = BigNumber::one();
 
-        for i in 1..alpha {
+        // Some bignumber backends don't consider `2` to be a prime,
+        // so we start the multiplication from `3`.
+        let mut primorial = BigNumber::one() * 2;
+
+        for i in 3..alpha {
             if BigNumber::from(i).is_prime() {
                 primorial *= i;
             }

--- a/src/crypto_tools/paillier/zk/range.rs
+++ b/src/crypto_tools/paillier/zk/range.rs
@@ -1,4 +1,4 @@
-use std::ops::Neg;
+use core::ops::Neg;
 
 use crate::{
     collections::TypedUsize,
@@ -349,6 +349,9 @@ pub mod malicious {
 }
 #[cfg(test)]
 mod tests {
+    use alloc::format;
+    use alloc::string::{String, ToString};
+
     use crate::{collections::TypedUsize, crypto_tools::paillier::keygen_unsafe};
 
     use super::{

--- a/src/crypto_tools/rng.rs
+++ b/src/crypto_tools/rng.rs
@@ -1,4 +1,4 @@
-use std::{
+use core::{
     array::TryFromSliceError,
     convert::{TryFrom, TryInto},
 };

--- a/src/crypto_tools/rng.rs
+++ b/src/crypto_tools/rng.rs
@@ -7,7 +7,7 @@ use ecdsa::elliptic_curve::generic_array::GenericArray;
 use hmac::{Hmac, Mac};
 use rand::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
-use sha2::Sha256;
+use sha2::{digest::Update, Sha256};
 use tracing::error;
 use zeroize::Zeroize;
 
@@ -49,14 +49,14 @@ pub(crate) fn rng_seed<K>(
         return Err(TofnFatal);
     }
 
-    let mut prf = Hmac::<Sha256>::new(secret_recovery_key.0[..].into());
-
     // TODO: Use protocol domain separation: https://github.com/axelarnetwork/tofn/issues/184
-    prf.update(&tag.to_be_bytes());
-    prf.update(&party_id.to_bytes());
-    prf.update(session_nonce);
-
-    let seed = prf.finalize().into_bytes().into();
+    let seed = Hmac::<Sha256>::new(secret_recovery_key.0[..].into())
+        .chain(tag.to_be_bytes())
+        .chain(party_id.to_bytes())
+        .chain(session_nonce)
+        .finalize()
+        .into_bytes()
+        .into();
 
     Ok(ChaCha20Rng::from_seed(seed))
 }
@@ -86,13 +86,13 @@ pub(crate) fn rng_seed_ecdsa_signing_key(
     // https://docs.rs/generic-array/0.14.4/src/generic_array/lib.rs.html#553-563
     let hmac_key: &GenericArray<_, _> = (secret_recovery_key.0[..]).into();
 
-    let mut prf = Hmac::<Sha256>::new(hmac_key);
-
-    prf.update(&protocol_tag.to_be_bytes());
-    prf.update(&tag.to_be_bytes());
-    prf.update(session_nonce);
-
-    let seed = prf.finalize().into_bytes().into();
+    let seed = Hmac::<Sha256>::new(hmac_key)
+        .chain(protocol_tag.to_be_bytes())
+        .chain(tag.to_be_bytes())
+        .chain(session_nonce)
+        .finalize()
+        .into_bytes()
+        .into();
 
     Ok(ChaCha20Rng::from_seed(seed))
 }
@@ -110,17 +110,17 @@ pub(crate) fn rng_seed_ecdsa_ephemeral_scalar_with_party_id<K>(
     let mut signing_key_bytes = signing_key.to_bytes();
     let msg_to_sign_bytes = msg_to_sign.to_bytes();
 
-    let mut prf = Hmac::<Sha256>::new(&Default::default());
-
     // TODO: Use protocol domain separation: https://github.com/axelarnetwork/tofn/issues/184
-    prf.update(&tag.to_be_bytes());
-    prf.update(&party_id.to_bytes());
-    prf.update(&signing_key_bytes);
-    prf.update(&msg_to_sign_bytes);
+    let seed = Hmac::<Sha256>::new(&Default::default())
+        .chain(tag.to_be_bytes())
+        .chain(party_id.to_bytes())
+        .chain(signing_key_bytes)
+        .chain(msg_to_sign_bytes)
+        .finalize()
+        .into_bytes()
+        .into();
 
     signing_key_bytes.zeroize();
-
-    let seed = prf.finalize().into_bytes().into();
 
     Ok(ChaCha20Rng::from_seed(seed))
 }
@@ -138,16 +138,16 @@ pub(crate) fn rng_seed_ecdsa_ephemeral_scalar(
     let mut signing_key_bytes = signing_key.to_bytes();
     let msg_to_sign_bytes = message_digest.to_bytes();
 
-    let mut prf = Hmac::<Sha256>::new(&Default::default());
-
-    prf.update(&protocol_tag.to_be_bytes());
-    prf.update(&tag.to_be_bytes());
-    prf.update(&signing_key_bytes);
-    prf.update(&msg_to_sign_bytes);
+    let seed = Hmac::<Sha256>::new(&Default::default())
+        .chain(protocol_tag.to_be_bytes())
+        .chain(tag.to_be_bytes())
+        .chain(signing_key_bytes)
+        .chain(msg_to_sign_bytes)
+        .finalize()
+        .into_bytes()
+        .into();
 
     signing_key_bytes.zeroize();
-
-    let seed = prf.finalize().into_bytes().into();
 
     Ok(ChaCha20Rng::from_seed(seed))
 }

--- a/src/crypto_tools/ss.rs
+++ b/src/crypto_tools/ss.rs
@@ -1,4 +1,8 @@
 //! Helpers for secret sharing
+
+use alloc::vec;
+use alloc::vec::Vec;
+
 use ecdsa::elliptic_curve::Field;
 use serde::{Deserialize, Serialize};
 // use tracing::error;
@@ -16,7 +20,7 @@ impl Ss {
         let secret_coeffs: Vec<k256::Scalar> = vec![alice_key]
             .into_iter()
             .chain(
-                std::iter::repeat_with(|| k256::Scalar::random(rand::thread_rng()))
+                core::iter::repeat_with(|| k256::Scalar::random(rand::thread_rng()))
                     .take(threshold - 1),
             )
             .collect();

--- a/src/crypto_tools/vss.rs
+++ b/src/crypto_tools/vss.rs
@@ -1,4 +1,7 @@
 //! Helpers for verifiable secret sharing
+
+use alloc::vec::Vec;
+
 use crate::{
     crypto_tools::k256_serde,
     sdk::api::{TofnFatal, TofnResult},
@@ -206,6 +209,8 @@ pub(crate) fn recover_secret(shares: &[Share]) -> k256::Scalar {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
     use rand::prelude::SliceRandom;
 

--- a/src/crypto_tools/zkp/pedersen.rs
+++ b/src/crypto_tools/zkp/pedersen.rs
@@ -234,6 +234,8 @@ pub mod malicious {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use ecdsa::elliptic_curve::{sec1::FromEncodedPoint, Field};
 
     use super::{

--- a/src/ecdsa/mod.rs
+++ b/src/ecdsa/mod.rs
@@ -3,12 +3,12 @@ use crate::{
     crypto_tools::{k256_serde, message_digest, rng},
     sdk::api::{Signature, TofnFatal, TofnResult},
 };
+use core::convert::TryInto;
 use ecdsa::{
     elliptic_curve::{sec1::ToEncodedPoint, Field},
     hazmat::{SignPrimitive, VerifyPrimitive},
 };
 use message_digest::MessageDigest;
-use std::convert::TryInto;
 use tracing::error;
 
 #[derive(Debug)]
@@ -105,7 +105,7 @@ const SIGN_TAG: u8 = 0x01;
 mod tests {
     use super::{keygen, sign, verify};
     use crate::{crypto_tools::rng::dummy_secret_recovery_key, multisig::sign::MessageDigest};
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn keygen_sign_decode_verify() {

--- a/src/gg20/keygen/r1.rs
+++ b/src/gg20/keygen/r1.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::TypedUsize,
     crypto_tools::{constants, hash, k256_serde, paillier, vss},

--- a/src/gg20/keygen/r2.rs
+++ b/src/gg20/keygen/r2.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -166,7 +168,7 @@ impl Executer for R2 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/keygen/r3.rs
+++ b/src/gg20/keygen/r3.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use serde::{Deserialize, Serialize};
 use tracing::warn;
 
@@ -263,7 +265,7 @@ impl Executer for R3 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/keygen/r4/happy.rs
+++ b/src/gg20/keygen/r4/happy.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use tracing::warn;
 
 use crate::{
@@ -116,7 +118,7 @@ impl Executer for R4Happy {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/keygen/r4/sad.rs
+++ b/src/gg20/keygen/r4/sad.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use tracing::{error, warn};
 
 use crate::{
@@ -137,7 +138,7 @@ impl Executer for R4Sad {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/keygen/secret_key_share.rs
+++ b/src/gg20/keygen/secret_key_share.rs
@@ -1,4 +1,5 @@
-use std::borrow::Borrow;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
 
 use super::{KeygenPartyId, KeygenPartyShareCounts, KeygenShareId, PartyKeyPair};
 use crate::{

--- a/src/gg20/keygen/tests.rs
+++ b/src/gg20/keygen/tests.rs
@@ -1,3 +1,8 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
 use super::*;
 use crate::{
     collections::{zip2, HoleVecMap, TypedUsize, VecMap},

--- a/src/gg20/sign/malicious.rs
+++ b/src/gg20/sign/malicious.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use tracing::info;
 
 use super::{r4, SignShareId};

--- a/src/gg20/sign/malicious.rs
+++ b/src/gg20/sign/malicious.rs
@@ -1,4 +1,3 @@
-use alloc::boxed::Box;
 use alloc::vec::Vec;
 
 use tracing::info;
@@ -124,7 +123,7 @@ pub fn delta_inverse_r4(
     faulter_bcast: &mut BytesVec,
     faulter_p2ps: &mut HoleVecMap<SignShareId, BytesVec>,
 ) {
-    let faulter_bcast_deserialized = match deserialize::<r4::Bcast>(
+    let mut faulter_bcast_deserialized = match deserialize::<r4::Bcast>(
         &decode_message::<SignShareId>(faulter_bcast)
             .unwrap()
             .payload,
@@ -151,21 +150,21 @@ pub fn delta_inverse_r4(
         }
         DeltaInvFaultType::beta_ij { victim } => {
             let p2p = faulter_p2ps_deserialized.get_mut(*victim).unwrap();
-            *Box::new(p2p.mta_plaintext.beta_secret.beta).as_mut() -= delta_i_change;
+            p2p.mta_plaintext.beta_secret.beta -= delta_i_change;
         }
         DeltaInvFaultType::k_i => {
-            *Box::new(faulter_bcast_deserialized.1.k_i).as_mut() -=
+            faulter_bcast_deserialized.1.k_i -=
                 delta_i_change * faulter_bcast_deserialized.1.gamma_i.invert().unwrap();
         }
         DeltaInvFaultType::gamma_i => {
-            *Box::new(faulter_bcast_deserialized.1.gamma_i).as_mut() -=
+            faulter_bcast_deserialized.1.gamma_i -=
                 delta_i_change * faulter_bcast_deserialized.1.k_i.invert().unwrap();
         }
         DeltaInvFaultType::Gamma_i_gamma_i => {
-            *Box::new(faulter_bcast_deserialized.1.gamma_i).as_mut() -=
+            faulter_bcast_deserialized.1.gamma_i -=
                 delta_i_change * faulter_bcast_deserialized.1.k_i.invert().unwrap();
-            *Box::new(&faulter_bcast_deserialized.0.Gamma_i).as_mut() =
-                &(ProjectivePoint::GENERATOR * faulter_bcast_deserialized.1.gamma_i)
+            faulter_bcast_deserialized.0.Gamma_i =
+                ProjectivePoint::GENERATOR * faulter_bcast_deserialized.1.gamma_i;
         }
     }
 

--- a/src/gg20/sign/r1.rs
+++ b/src/gg20/sign/r1.rs
@@ -1,4 +1,6 @@
-use std::borrow::Borrow;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
 
 use crate::{
     collections::TypedUsize,

--- a/src/gg20/sign/r2.rs
+++ b/src/gg20/sign/r2.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{FillVecMap, P2ps, TypedUsize},
     crypto_tools::{
@@ -259,7 +261,7 @@ impl Executer for R2 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r3/common.rs
+++ b/src/gg20/sign/r3/common.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use tracing::warn;
 
 use crate::{

--- a/src/gg20/sign/r3/happy.rs
+++ b/src/gg20/sign/r3/happy.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use super::super::{r1, r2, Peers, SignShareId};
 use crate::{
     collections::{FillVecMap, FullP2ps, HoleVecMap, P2ps, TypedUsize, VecMap},
@@ -313,7 +316,7 @@ impl Executer for R3Happy {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r3/sad.rs
+++ b/src/gg20/sign/r3/sad.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{zip2, FillVecMap, FullP2ps, P2ps, VecMap},
     crypto_tools::paillier,
@@ -119,7 +121,7 @@ impl Executer for R3Sad {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r4/happy.rs
+++ b/src/gg20/sign/r4/happy.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{zip2, FillVecMap, FullP2ps, HoleVecMap, P2ps, TypedUsize, VecMap},
     crypto_tools::{hash::Randomness, k256_serde, mta::Secret, paillier, zkp::pedersen},
@@ -219,7 +221,7 @@ impl Executer for R4Happy {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r4/sad.rs
+++ b/src/gg20/sign/r4/sad.rs
@@ -1,3 +1,7 @@
+use alloc::boxed::Box;
+use alloc::format;
+use alloc::vec::Vec;
+
 use crate::{
     collections::{zip2, FillVecMap, FullP2ps, P2ps, VecMap},
     crypto_tools::{paillier, vss},
@@ -183,7 +187,7 @@ impl Executer for R4Sad {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r5/common.rs
+++ b/src/gg20/sign/r5/common.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use tracing::warn;
 
 use crate::{

--- a/src/gg20/sign/r5/happy.rs
+++ b/src/gg20/sign/r5/happy.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{FillVecMap, FullP2ps, HoleVecMap, P2ps, TypedUsize, VecMap},
     crypto_tools::{
@@ -213,7 +215,7 @@ impl Executer for R5 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r5/type5.rs
+++ b/src/gg20/sign/r5/type5.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{FillVecMap, FullP2ps, P2ps, VecMap},
     gg20::{
@@ -102,7 +104,7 @@ impl Executer for R5Type5 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r6.rs
+++ b/src/gg20/sign/r6.rs
@@ -320,8 +320,6 @@ impl Executer for R6 {
 #[cfg(feature = "malicious")]
 mod malicious {
 
-    use alloc::boxed::Box;
-
     use super::R6;
     use crate::{
         collections::{HoleVecMap, TypedUsize},
@@ -368,10 +366,11 @@ mod malicious {
             recipient: TypedUsize<SignShareId>,
             beta_secret: Secret,
         ) -> Secret {
+            let mut beta_secret = beta_secret;
             if let R3BadBeta { victim } = self.behaviour {
                 if victim == recipient {
                     log_confess_info(my_sign_id, &self.behaviour, "step 2/2: beta_secret");
-                    *Box::new(beta_secret.beta).as_mut() += k256::Scalar::ONE;
+                    beta_secret.beta += k256::Scalar::ONE;
                 }
             }
             beta_secret

--- a/src/gg20/sign/r6.rs
+++ b/src/gg20/sign/r6.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use super::{
     r1, r2, r3, r4, r5, r7,
     type5_common::{BcastSadType5, MtaPlaintext, P2pSadType5},
@@ -310,13 +312,16 @@ impl Executer for R6 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }
 
 #[cfg(feature = "malicious")]
 mod malicious {
+
+    use alloc::boxed::Box;
+
     use super::R6;
     use crate::{
         collections::{HoleVecMap, TypedUsize},

--- a/src/gg20/sign/r7/common.rs
+++ b/src/gg20/sign/r7/common.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use tracing::{error, warn};
 
 use crate::{

--- a/src/gg20/sign/r7/happy.rs
+++ b/src/gg20/sign/r7/happy.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{FillVecMap, FullP2ps, P2ps, TypedUsize, VecMap},
     crypto_tools::{
@@ -235,7 +237,7 @@ impl Executer for R7Happy {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r7/sad.rs
+++ b/src/gg20/sign/r7/sad.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{zip2, FillVecMap, FullP2ps, P2ps, VecMap},
     crypto_tools::paillier,
@@ -133,7 +135,7 @@ impl Executer for R7Sad {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r7/type5.rs
+++ b/src/gg20/sign/r7/type5.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{zip2, FillVecMap, FullP2ps, P2ps, VecMap},
     gg20::{
@@ -135,7 +137,7 @@ impl Executer for R7Type5 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r8/common.rs
+++ b/src/gg20/sign/r8/common.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use tracing::warn;
 
 use crate::{

--- a/src/gg20/sign/r8/happy.rs
+++ b/src/gg20/sign/r8/happy.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::{FillVecMap, P2ps, VecMap},
     gg20::{keygen::SecretKeyShare, sign::r8::common::R8Path},
@@ -126,7 +128,7 @@ impl Executer for R8Happy {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/r8/type7.rs
+++ b/src/gg20/sign/r8/type7.rs
@@ -1,4 +1,6 @@
-use std::borrow::Borrow;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::borrow::Borrow;
 
 use crate::{
     collections::{zip2, FillVecMap, FullP2ps, P2ps, TypedUsize, VecMap},
@@ -259,7 +261,7 @@ impl Executer for R8Type7 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/gg20/sign/tests.rs
+++ b/src/gg20/sign/tests.rs
@@ -1,4 +1,8 @@
-use std::convert::TryFrom;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use super::*;
 use crate::{

--- a/src/gg20/sign/type5_common.rs
+++ b/src/gg20/sign/type5_common.rs
@@ -1,4 +1,4 @@
-use std::borrow::Borrow;
+use core::borrow::Borrow;
 
 use k256::ProjectivePoint;
 use serde::{Deserialize, Serialize};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,12 @@
+#![no_std]
+
+// `traced_test`attribute depends on `std`, so we enable it in tests.
+// TODO: probably can be fixed in `tracing`.
+#[cfg(test)]
+extern crate std;
+
+extern crate alloc;
+
 pub mod collections;
 mod constants;
 // todo(tk): made crypto tools public to use MessageDigest in cli; make private again

--- a/src/multisig/keygen/r1.rs
+++ b/src/multisig/keygen/r1.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::{
     collections::TypedUsize,
     crypto_tools::{k256_serde, rng},

--- a/src/multisig/keygen/r2.rs
+++ b/src/multisig/keygen/r2.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use tracing::warn;
 
 use crate::{
@@ -69,7 +70,7 @@ impl Executer for R2 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/multisig/keygen/secret_key_share.rs
+++ b/src/multisig/keygen/secret_key_share.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::{KeygenPartyId, KeygenPartyShareCounts, KeygenShareId};
 use crate::{
     collections::{TypedUsize, VecMap},

--- a/src/multisig/keygen/tests.rs
+++ b/src/multisig/keygen/tests.rs
@@ -1,3 +1,8 @@
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+
 use super::{secret_key_share::SecretKeyShare, *};
 use crate::{
     collections::VecMap,

--- a/src/multisig/sign/api.rs
+++ b/src/multisig/sign/api.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use super::r1;
 use crate::{
     collections::{HoleVecMap, Subset, TypedUsize, VecMap},

--- a/src/multisig/sign/r1.rs
+++ b/src/multisig/sign/r1.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use super::{r2, KeygenShareIds, MessageDigest, SignProtocolBuilder, SignShareId};
 use crate::{
     collections::TypedUsize,

--- a/src/multisig/sign/r2.rs
+++ b/src/multisig/sign/r2.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use super::{r1, KeygenShareIds, SignProtocolOutput, SignShareId, SignatureShare};
 use crate::{
     collections::{zip2, FillVecMap, P2ps},
@@ -119,7 +122,7 @@ impl Executer for R2 {
     }
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self
     }
 }

--- a/src/multisig/sign/tests.rs
+++ b/src/multisig/sign/tests.rs
@@ -1,4 +1,8 @@
-use std::convert::TryFrom;
+use alloc::format;
+use alloc::string::{String, ToString};
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
 
 use super::*;
 use crate::{

--- a/src/sdk/api.rs
+++ b/src/sdk/api.rs
@@ -1,4 +1,6 @@
 //! API for tofn users
+use alloc::vec::Vec;
+
 pub use k256::ecdsa::{recoverable::Signature as RecoverableSignature, Signature, VerifyingKey};
 
 use ecdsa::hazmat::VerifyPrimitive;

--- a/src/sdk/executer.rs
+++ b/src/sdk/executer.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use serde::de::DeserializeOwned;
 use tracing::warn;
 
@@ -28,7 +31,7 @@ pub trait Executer: Send + Sync {
     ) -> TofnResult<ProtocolBuilder<Self::FinalOutput, Self::Index>>;
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         unimplemented!("(Executer) return `self` to enable runtime reflection: https://bennetthardwick.com/dont-use-boxed-trait-objects-for-struct-internals")
     }
 }
@@ -47,7 +50,7 @@ pub trait ExecuterRaw: Send + Sync {
     ) -> TofnResult<ProtocolBuilder<Self::FinalOutput, Self::Index>>;
 
     #[cfg(test)]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         unimplemented!("(ExecuterRaw) return `self` to enable runtime reflection: https://bennetthardwick.com/dont-use-boxed-trait-objects-for-struct-internals")
     }
 }
@@ -121,7 +124,7 @@ impl<T: Executer> ExecuterRaw for T {
 
     #[cfg(test)]
     #[inline]
-    fn as_any(&self) -> &dyn std::any::Any {
+    fn as_any(&self) -> &dyn core::any::Any {
         self.as_any()
     }
 }

--- a/src/sdk/party_share_counts.rs
+++ b/src/sdk/party_share_counts.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use crate::{
     collections::{Subset, TypedUsize, VecMap, VecMapIter},
     sdk::api::{TofnFatal, TofnResult, MAX_PARTY_SHARE_COUNT, MAX_TOTAL_SHARE_COUNT},
@@ -46,7 +48,7 @@ impl<P> PartyShareCounts<P> {
     pub fn party_count(&self) -> usize {
         self.party_share_counts.len()
     }
-    pub fn iter(&self) -> VecMapIter<P, std::slice::Iter<usize>> {
+    pub fn iter(&self) -> VecMapIter<P, core::slice::Iter<usize>> {
         self.party_share_counts.iter()
     }
     pub fn share_to_party_subshare_ids<K>(
@@ -152,6 +154,8 @@ impl<P> PartyShareCounts<P> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
 
     struct TestParty;
@@ -195,7 +199,7 @@ mod tests {
     }
 
     fn subset<P>(max_size: usize, vec: Vec<usize>) -> Subset<P> {
-        let len = std::cmp::max(max_size, vec.len());
+        let len = core::cmp::max(max_size, vec.len());
         let mut output = Subset::with_max_size(len);
         for i in vec {
             output.add(TypedUsize::from_usize(i)).unwrap();

--- a/src/sdk/protocol_builder.rs
+++ b/src/sdk/protocol_builder.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+
 use crate::collections::{FillVecMap, HoleVecMap};
 
 use super::{

--- a/src/sdk/round.rs
+++ b/src/sdk/round.rs
@@ -1,3 +1,6 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use tracing::{debug, error, info, warn};
 
 use crate::{
@@ -333,7 +336,7 @@ impl<F, K, P, const MAX_MSG_IN_LEN: usize> Round<F, K, P, MAX_MSG_IN_LEN> {
     }
 
     #[cfg(test)]
-    pub fn round_as_any(&self) -> &dyn std::any::Any {
+    pub fn round_as_any(&self) -> &dyn core::any::Any {
         self.round.as_any()
     }
 

--- a/src/sdk/wire_bytes.rs
+++ b/src/sdk/wire_bytes.rs
@@ -1,3 +1,5 @@
+use alloc::string::ToString;
+
 use crate::{collections::TypedUsize, sdk::api::TofnFatal};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tracing::{error, warn};
@@ -143,6 +145,9 @@ struct BytesVecVersioned {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
     use bincode::{DefaultOptions, Options};
 
     use crate::sdk::wire_bytes::{decode, deserialize, encode, serialize, MAX_MSG_LEN};

--- a/tests/integration/common.rs
+++ b/tests/integration/common.rs
@@ -1,4 +1,4 @@
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use tofn::{collections::TypedUsize, gg20::keygen::SecretRecoveryKey};
 

--- a/tests/integration/single_thread/malicious/sign.rs
+++ b/tests/integration/single_thread/malicious/sign.rs
@@ -2,7 +2,7 @@ use crate::{
     common::keygen,
     single_thread::{execute::execute_protocol, set_up_logs},
 };
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 use tofn::{
     collections::{FillVecMap, TypedUsize, VecMap},
     gg20::{

--- a/tests/integration/single_thread/malicious/sign_delta_inv.rs
+++ b/tests/integration/single_thread/malicious/sign_delta_inv.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use tofn::{
     collections::{FillVecMap, HoleVecMap, TypedUsize, VecMap},

--- a/tests/integration/single_thread/malicious/timeout_corrupt.rs
+++ b/tests/integration/single_thread/malicious/timeout_corrupt.rs
@@ -97,8 +97,8 @@ fn execute_test_case<F, K, P, const MAX_MSG_IN_LEN: usize>(
     shares: VecMap<K, Protocol<F, K, P, MAX_MSG_IN_LEN>>,
     test_case: SingleFaulterTestCase<K, P>,
 ) where
-    K: PartialEq + std::fmt::Debug + Clone + Copy, // TODO can't quite escape ugly trait bounds :(
-    P: PartialEq + std::fmt::Debug + Clone + Copy,
+    K: PartialEq + core::fmt::Debug + Clone + Copy, // TODO can't quite escape ugly trait bounds :(
+    P: PartialEq + core::fmt::Debug + Clone + Copy,
 {
     let shares = execute_protocol(shares, &test_case).expect("internal tofn error");
 

--- a/tests/integration/single_thread/mod.rs
+++ b/tests/integration/single_thread/mod.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use crate::common;
 use ecdsa::hazmat::VerifyPrimitive;


### PR DESCRIPTION
Make `tofn` no-std to prepare the ground for WASM support when the required PR is merged in libpaillier (see https://github.com/entropyxyz/tofn/pull/27). Plus some minor fixes.