### PR TITLE
Compatibility fix for the mainstream `libpaillier`

### DIFF
--- a/benches/safe_primes.rs
+++ b/benches/safe_primes.rs
@@ -13,10 +13,10 @@ pub fn safe_primes(c: &mut Criterion) {
 
     g.bench_function("unsafe primes", |b| {
         b.iter(|| {
-            let p = BigNumber::prime_with_rng(&mut rng, 1024);
-            let q = BigNumber::prime_with_rng(&mut rng, 1024);
+            let p = BigNumber::prime_from_rng(1024, &mut rng);
+            let q = BigNumber::prime_from_rng(1024, &mut rng);
 
-            let dk = DecryptionKey::with_safe_primes_unchecked(&p, &q).unwrap();
+            let dk = DecryptionKey::with_primes_unchecked(&p, &q).unwrap();
 
             let ek: EncryptionKey = dk.borrow().into();
 
@@ -28,7 +28,7 @@ pub fn safe_primes(c: &mut Criterion) {
 
     g.bench_function("safe primes", |b| {
         b.iter(|| {
-            let dk = DecryptionKey::with_rng(&mut rng).unwrap();
+            let dk = DecryptionKey::from_rng_with_safe_primes(&mut rng).unwrap();
 
             let ek: EncryptionKey = dk.borrow().into();
 

--- a/src/crypto_tools/mta.rs
+++ b/src/crypto_tools/mta.rs
@@ -44,7 +44,7 @@ pub fn mta_response_from_randomness(
     beta_prime: &Plaintext,
     beta_prime_randomness: &Randomness,
 ) -> (Ciphertext, k256::Scalar) {
-    let beta_prime_ciphertext = a_ek.encrypt_with_randomness(beta_prime, beta_prime_randomness);
+    let beta_prime_ciphertext = a_ek.encrypt_unchecked(beta_prime, beta_prime_randomness);
     let c_b = a_ek.add(
         &a_ek.mul(a_ciphertext, &Plaintext::from_scalar(b)),
         &beta_prime_ciphertext,

--- a/src/crypto_tools/paillier/mod.rs
+++ b/src/crypto_tools/paillier/mod.rs
@@ -22,10 +22,10 @@ pub mod zk;
 pub fn keygen_unsafe(
     rng: &mut (impl CryptoRng + RngCore),
 ) -> TofnResult<(EncryptionKey, DecryptionKey)> {
-    let p = BigNumber::prime_with_rng(rng, 1024);
-    let q = BigNumber::prime_with_rng(rng, 1024);
+    let p = BigNumber::prime_from_rng(1024, rng);
+    let q = BigNumber::prime_from_rng(1024, rng);
 
-    let dk = libpaillier::DecryptionKey::with_safe_primes_unchecked(&p, &q).ok_or(TofnFatal)?;
+    let dk = libpaillier::DecryptionKey::with_primes_unchecked(&p, &q).ok_or(TofnFatal)?;
     let ek = dk.borrow().into();
 
     Ok((EncryptionKey(ek), DecryptionKey(dk)))
@@ -33,7 +33,7 @@ pub fn keygen_unsafe(
 
 /// Generate a Paillier keypair (using safe primes)
 pub fn keygen(rng: &mut (impl CryptoRng + RngCore)) -> TofnResult<(EncryptionKey, DecryptionKey)> {
-    let dk = libpaillier::DecryptionKey::with_rng(rng).ok_or(TofnFatal)?;
+    let dk = libpaillier::DecryptionKey::from_rng_with_safe_primes(rng).ok_or(TofnFatal)?;
     let ek = dk.borrow().into();
 
     Ok((EncryptionKey(ek), DecryptionKey(dk)))
@@ -80,11 +80,11 @@ impl EncryptionKey {
         // Sampling a random integer mod N has negligible probability of not being co-prime
         let r = self.sample_randomness();
 
-        (self.encrypt_with_randomness(p, &r), r)
+        (self.encrypt_unchecked(p, &r), r)
     }
 
-    pub fn encrypt_with_randomness(&self, p: &Plaintext, r: &Randomness) -> Ciphertext {
-        Ciphertext(self.0.encrypt_with_randomness(&p.0, &r.0))
+    pub fn encrypt_unchecked(&self, p: &Plaintext, r: &Randomness) -> Ciphertext {
+        Ciphertext(self.0.encrypt_unchecked(&p.0, &r.0))
     }
 
     /// Homomorphically add `c1` to `c2`
@@ -165,7 +165,7 @@ impl Randomness {
 
     /// Generate a random number in the range `[0, n)` with the provided `rng`
     pub fn generate_with_rng(rng: &mut (impl CryptoRng + RngCore), n: &BigNumber) -> Self {
-        Self(BigNumber::random_with_rng(rng, n))
+        Self(BigNumber::from_rng(n, rng))
     }
 }
 

--- a/src/crypto_tools/paillier/zk/composite_dlog.rs
+++ b/src/crypto_tools/paillier/zk/composite_dlog.rs
@@ -121,7 +121,7 @@ impl CompositeDLogStmtBase {
 
         loop {
             // Sample an asymmetric basis g
-            let g = BigNumber::random_with_rng(rng, n);
+            let g = BigNumber::from_rng(n, rng);
 
             // g is asymmetric when Jacobi symbol (g | n) = -1
             if jacobi_symbol(&g, p, q) != -1 {
@@ -132,7 +132,7 @@ impl CompositeDLogStmtBase {
             // If p and q are safe primes, then any odd number `s` is invertible with very high probability.
             // If p and q are not safe primes, then this can occur often, and we need to resample.
             let (s, s_inv) = loop {
-                let s = SecretNumber((BigNumber::random_with_rng(rng, &S_div_2) << 1) + 1);
+                let s = SecretNumber((BigNumber::from_rng(&S_div_2, rng) << 1) + 1);
 
                 // Inversion will fail if s is not co-prime to phi(N)
                 match s.0.invert(totient) {

--- a/src/crypto_tools/paillier/zk/mta.rs
+++ b/src/crypto_tools/paillier/zk/mta.rs
@@ -202,7 +202,7 @@ impl ZkSetup {
         });
 
         // v = c1^alpha Paillier-Enc(gamma, beta) mod N^2
-        let v = stmt.ek.encrypt_with_randomness(&gamma, &beta).0.modmul(
+        let v = stmt.ek.encrypt_unchecked(&gamma, &beta).0.modmul(
             &stmt.ciphertext1.0.modpow(&alpha.0, stmt.ek.0.nn()),
             stmt.ek.0.nn(),
         );
@@ -395,14 +395,10 @@ impl ZkSetup {
         }
 
         // c1^s1 s^N Gamma^t1 ?= c2^e v mod N^2
-        let cipher_check_lhs = stmt
-            .ek
-            .encrypt_with_randomness(&proof.t1, &proof.s)
-            .0
-            .modmul(
-                &stmt.ciphertext1.0.modpow(&proof.s1.0, stmt.ek.0.nn()),
-                stmt.ek.0.nn(),
-            );
+        let cipher_check_lhs = stmt.ek.encrypt_unchecked(&proof.t1, &proof.s).0.modmul(
+            &stmt.ciphertext1.0.modpow(&proof.s1.0, stmt.ek.0.nn()),
+            stmt.ek.0.nn(),
+        );
         let cipher_check_rhs = proof.v.modmul(
             &stmt.ciphertext2.0.modpow(&e_bigint, stmt.ek.0.nn()),
             stmt.ek.0.nn(),
@@ -470,7 +466,7 @@ pub(crate) mod tests {
         let ciphertext1 = &Ciphertext(BigNumber::random(ek.0.nn()));
         let ciphertext2 = &ek.add(
             &ek.mul(ciphertext1, &Plaintext::from_scalar(x)),
-            &ek.encrypt_with_randomness(msg, randomness),
+            &ek.encrypt_unchecked(msg, randomness),
         );
         let prover_id = TypedUsize::from_usize(1);
         let verifier_id = TypedUsize::from_usize(4);

--- a/src/crypto_tools/paillier/zk/range.rs
+++ b/src/crypto_tools/paillier/zk/range.rs
@@ -292,14 +292,10 @@ impl ZkSetup {
         }
 
         // u ?= Paillier-Enc(s1, s) * c^(-e) mod N^2
-        let u_check = stmt
-            .ek
-            .encrypt_with_randomness(&proof.s1, &proof.s)
-            .0
-            .modmul(
-                &stmt.ciphertext.0.modpow(&e_neg_bigint, stmt.ek.0.nn()),
-                stmt.ek.0.nn(),
-            );
+        let u_check = stmt.ek.encrypt_unchecked(&proof.s1, &proof.s).0.modmul(
+            &stmt.ciphertext.0.modpow(&e_neg_bigint, stmt.ek.0.nn()),
+            stmt.ek.0.nn(),
+        );
         if u_check != proof.u.0 {
             warn!("range proof: u check failed");
             return false;

--- a/src/gg20/keygen/r4/sad.rs
+++ b/src/gg20/keygen/r4/sad.rs
@@ -96,7 +96,7 @@ impl Executer for R4Sad {
                 }
 
                 // verify encryption
-                let share_ciphertext = accuser_ek.encrypt_with_randomness(
+                let share_ciphertext = accuser_ek.encrypt_unchecked(
                     &accusation.share.get_scalar().into(),
                     &accusation.randomness,
                 );

--- a/src/gg20/sign/r8/type7.rs
+++ b/src/gg20/sign/r8/type7.rs
@@ -138,7 +138,7 @@ impl Executer for R8Type7 {
 
             // k_i
             let k_i_ciphertext =
-                peer_ek.encrypt_with_randomness(&bcast.k_i.borrow().into(), &bcast.k_i_randomness);
+                peer_ek.encrypt_unchecked(&bcast.k_i.borrow().into(), &bcast.k_i_randomness);
             if k_i_ciphertext != self.r1bcasts.get(peer_sign_id)?.k_i_ciphertext {
                 warn!(
                     "peer {} says: invalid k_i detected from peer {}",
@@ -151,7 +151,7 @@ impl Executer for R8Type7 {
 
             // mu_ij
             for (receiver_sign_id, peer_mta_wc_plaintext) in peer_p2ps {
-                let peer_mu_ciphertext = peer_ek.encrypt_with_randomness(
+                let peer_mu_ciphertext = peer_ek.encrypt_unchecked(
                     &peer_mta_wc_plaintext.mu_plaintext,
                     &peer_mta_wc_plaintext.mu_randomness,
                 );

--- a/src/gg20/sign/type5_common.rs
+++ b/src/gg20/sign/type5_common.rs
@@ -113,7 +113,7 @@ pub fn type5_checks(
         }
 
         // k_i
-        let k_i_ciphertext = peer_ek.encrypt_with_randomness(
+        let k_i_ciphertext = peer_ek.encrypt_unchecked(
             &bcast_type5.k_i.borrow().into(),
             &bcast_type5.k_i_randomness,
         );
@@ -184,7 +184,7 @@ pub fn type5_checks(
             }
 
             // alpha_ij
-            let peer_alpha_ciphertext = peer_ek.encrypt_with_randomness(
+            let peer_alpha_ciphertext = peer_ek.encrypt_unchecked(
                 &peer_mta_plaintext.alpha_plaintext,
                 &peer_mta_plaintext.alpha_randomness,
             );


### PR DESCRIPTION
Based on https://github.com/mikelodder7/unknown_order/pull/7 and https://github.com/mikelodder7/paillier-rs/pull/4

---

Notes for switching to Rust backend:

`glass_pumpkin` in the Rust backend of `unknown_order` implements slightly different primality checking - `log2(bitsize) + 5` Miller-Rabin rounds instead of fixed 25 in the GMP backend. But it comes out same for 2048 bit though, which is the default size used AFAIU). `glass_pumpkin` also has Baillie-OEIS method available, but it is not used by default.

The failures in the tests (namely, inability to find an invertible `s` in `CompositeDLogStmtBase::setup()`) seem to have been caused by a bug in random number generation in the Rust backend - when the requested bitsize was not a multiple of 8, it was rounded down to the lowest multiple of 8. Not sure how that affected the search for an invertible `s`, but fixing that helped.

Note that Rust backend is about 2x slower than GMP (in release build) when generating primes. And super slow in debug. But I suppose it is a small price to pay for WASM support?