### PR TITLE
Update README.md `cargo build --release` cmd fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ceygen only (Entropy CLI instructions)
 ```
-cargo build release
+cargo build --release
 # generate 2-of-2 keys. Note that threshold of 1 implies the need for 2 parties.
 # writes to tofn_ceygen_<timestamp>
 ./target/release/tofn ceygen -p 2 -t 1 


### PR DESCRIPTION
The `cargo build --release` command was incorrect as it returns:

```
❯ cargo build release
error: unexpected argument 'release' found
```
The correct cmd is `cargo build --release`